### PR TITLE
Include size of unused hash buckets when computing map size.

### DIFF
--- a/size.go
+++ b/size.go
@@ -100,7 +100,9 @@ func sizeOf(v reflect.Value, cache map[uintptr]bool) int {
 			}
 			sum += sk
 		}
-		return sum + int(v.Type().Size())
+		// Include overhead due to unused map buckets.  10.79 comes
+		// from https://golang.org/src/runtime/map.go.
+		return sum + int(v.Type().Size()) + int(float64(len(keys)) * 10.79)
 
 	case reflect.Interface:
 		return sizeOf(v.Elem(), cache) + int(v.Type().Size())

--- a/test_cases.go
+++ b/test_cases.go
@@ -108,7 +108,7 @@ func testCases() []testCase {
 		v8.data[i].parent = &v8
 	}
 
-	var v9 = make(map[int]string) // 90 + 8 = 98 - size of Map is 8
+	var v9 = make(map[int]string) // 90 + 8 + 10.79*3 = 130 - size of Map is 8
 	v9[0] = "ABC"                 // 8 + 3 + 16 = 27
 	v9[1] = "CDEFG"               // 8 + 5 + 16 = 29
 	v9[2] = "ABCDEFGHHI"          // 8 + 10 + 16 = 34
@@ -165,7 +165,7 @@ func testCases() []testCase {
 		{
 			name: "v9",
 			v:    v9,
-			want: 98,
+			want: 130,
 		},
 		{
 			name: "v10",


### PR DESCRIPTION
This was suggested by
   https://stackoverflow.com/questions/51431933/how-to-get-size-of-struct-containing-data-structures-in-go

Fixes #1