### PR TITLE
Properly record sizes when two strings are aliased to the same memory.

### DIFF
--- a/test_cases.go
+++ b/test_cases.go
@@ -120,6 +120,9 @@ func testCases() []testCase {
 
 	v12 := make(chan int) // 8 - size of chan in Go
 
+	s := "JKLMNOPQRSTUVWX"
+	v13 := struct{ x, y string }{x: s, y: s} // 47 - only count len(s) once
+
 	v14 := struct { // 29 - due to padding
 		i int8
 		s string
@@ -188,6 +191,11 @@ func testCases() []testCase {
 			name: "v12",
 			v:    v12,
 			want: 8,
+		},
+		{
+			name: "v13",
+			v:    v13,
+			want: 47,
 		},
 		{
 			name: "v14",


### PR DESCRIPTION
If you do
```
   a := "some very long .... string"
   b := a
```
Then `a` and `b` both point to the same memory.  If you do
```
   size.Of([]string{a, b})
```
it should only count the content of the very-long string once.  (But
still count the string header two times, as `a` and `b` each have
their own separate header.)

This commit makes that happen.  Sadly, it means that size.go now
depends on the "unsafe" package, which is not implemented in some
environments (such as appengine.)