### PR TITLE
Account for the full capacity of slices

### DIFF
--- a/size.go
+++ b/size.go
@@ -41,6 +41,9 @@ func sizeOf(v reflect.Value, cache map[uintptr]bool) int {
 			}
 			sum += s
 		}
+
+		sum += (v.Cap() - v.Len()) * int(v.Type().Elem().Size())
+
 		return sum + int(v.Type().Size())
 
 	case reflect.Struct:

--- a/test_cases.go
+++ b/test_cases.go
@@ -131,6 +131,10 @@ func testCases() []testCase {
 		s: "hello", // 5 + 16
 	}
 
+	v15 := make([]string, 2, 5) // 24 + 19 + 21 + (5 - 2) * 16 = 112
+	v15[0] = "ABC"              // 3 + 16 = 19
+	v15[1] = "CDEFG"            // 5 + 16 = 21
+
 	tests := []testCase{
 		{
 			name: "v1",
@@ -201,6 +205,11 @@ func testCases() []testCase {
 			name: "v14",
 			v:    v14,
 			want: 29,
+		},
+		{
+			name: "v15",
+			v:    v15,
+			want: 112,
 		},
 	}
 	return tests


### PR DESCRIPTION
A slice's capacity may be larger than its length, either because it was explicitly created this way or due to the dynamic resizing that happens when new elements are appended.
The memory occupied by the extra capacity is the size of the element type multiplied by the number of non-assigned elements.